### PR TITLE
fix: slow down marquee animation for better readability

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3134,7 +3134,7 @@ a.community-card-link {
     display: flex;
     gap: var(--space-lg);
     width: max-content;
-    animation: scroll-voices 60s linear infinite;
+    animation: scroll-voices 120s linear infinite;
 }
 
 /* Pause on container hover (not track) to prevent jitter between cards */


### PR DESCRIPTION
Increased the marquee scroll duration from 60s to 120s to give users more time to read parent testimonials in the Problem Statement section.

This reduces scrolling speed by 50%, making the text significantly more readable.

Fixes #8

---

Generated with [Claude Code](https://claude.ai/code)