### PR TITLE
Auto-confirm subscribers without incentive email

### DIFF
--- a/welcome.html
+++ b/welcome.html
@@ -763,8 +763,7 @@
                 <h1 class="welcome-title">Welcome to the Lumicello Family</h1>
 
                 <p class="welcome-message">
-                    Your subscription is confirmed! <strong>Check your inbox</strong> for a welcome email from us.
-                    We're so excited to have you on this journey of nurturing your child's natural curiosity.
+                    Your subscription is confirmed! We're so excited to have you on this journey of nurturing your child's natural curiosity.
                 </p>
             </div>
         </section>


### PR DESCRIPTION
Kit.com now auto-confirms subscribers without sending an incentive email, so the "check your inbox" message is no longer accurate.