### PR TITLE
Replace 'expert-led' with 'research-backed' across all pages

### DIFF
--- a/design_specs/company_context.md
+++ b/design_specs/company_context.md
@@ -7,7 +7,7 @@ Reference: internal brand & messaging document  ￼
 1. What Lumicello Is
 
 Lumicello is a personalized learning platform for children and families.
-It blends expert-led guidance, AI-driven customization, and adaptive pacing to create individualized learning journeys — digital and physical.
+It blends research-backed guidance, AI-driven customization, and adaptive pacing to create individualized learning journeys — digital and physical.
 
 Parents and educators use Lumicello to understand what truly interests a child, track progress, and support them with the right resources at the right time.
 
@@ -25,10 +25,10 @@ Lumicello is built for learners, parents, and educators, not just tech-savvy use
 
 Lumicello is built around three beliefs:
 
-1) Expert-Led
+1) Research-Backed
 
 Technology amplifies teacher wisdom, not replaces it.
-Parents and educators get insight into each child’s unique learning pattern so they can guide them better.
+Parents and educators get insight into each child's unique learning pattern so they can guide them better.
 
 2) Customized
 
@@ -173,7 +173,7 @@ Community Section (immediately after Hero)
 	•	Prioritizes community building and early engagement
 
 Value Props
-	•	3 cards: "Expert-Led," "Customized," "Right Pace"
+	•	3 cards: "Research-Backed," "Customized," "Right Pace"
 	•	Icons: Soft, colorful SVG icons
 
 Curiosity Fingerprint™

--- a/design_specs/website_specs_requirements.md
+++ b/design_specs/website_specs_requirements.md
@@ -112,7 +112,7 @@ Use CSS Grid to create the "Poketo" bento-box feel.
       * Newsletter signup form (Name + Email).
       * Placed immediately after Hero to prioritize community building.
 3.  **Value Prop (The "Headspace" Cards):**
-      * 3 cards horizontally: "Expert-Led," "Customized," "Right Pace."
+      * 3 cards horizontally: "Research-Backed," "Customized," "Right Pace."
       * Icons: Soft, colorful SVG icons.
 4.  **Curiosity Fingerprint:**
       * Visual data visualization showing the personalized learning concept.

--- a/index.html
+++ b/index.html
@@ -421,7 +421,7 @@
                     </div>
                 </div>
 
-                <!-- Expert-Led Card -->
+                <!-- Research-Backed Card -->
                 <div class="bento-card clay">
                     <div class="bento-icon">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -430,7 +430,7 @@
                             <path d="M12 14v7"/>
                         </svg>
                     </div>
-                    <h3>Expert-Led</h3>
+                    <h3>Research-Backed</h3>
                     <p>Technology amplifies teacher wisdom, not replaces it. Parents and educators guide with deeper insight.</p>
                 </div>
 


### PR DESCRIPTION
Updated value proposition terminology to emphasize research-backed approach rather than expert-led, maintaining brand reliability while focusing on research citations rather than human experts.

## Changes
- index.html: Updated bento card heading and comment
- design_specs/website_specs_requirements.md: Updated value prop description
- design_specs/company_context.md: Updated all references (intro, core beliefs, and layout specs)

Fixes #15

Generated with [Claude Code](https://claude.ai/code)