### PR TITLE
Add voucher-terms.html to build whitelist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,9 +231,23 @@ img-src: https://new-domain.com       # If loading images
 ## Deployment
 
 ### Render.com Static Site
-- **Build Command:** (empty - pure static)
-- **Publish Directory:** `./` (root)
+- **Build Command:** `node build.js`
+- **Publish Directory:** `dist`
 - **Entry Point:** `index.html`
+
+### Adding New HTML Pages
+
+**IMPORTANT:** When creating a new HTML page, you MUST add it to the `PUBLIC_FILES` array in `build.js`. The build uses a whitelist approach - only files explicitly listed get deployed. If you forget this step, the page will return 404 in production.
+
+```javascript
+// In build.js, add your new page to this array:
+const PUBLIC_FILES = [
+    'index.html',
+    'contact.html',
+    // ... add your new page here
+    'your-new-page.html',
+];
+```
 
 ### Pre-deployment Checklist
 - [ ] Verify all images load (webp format)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,6 +249,20 @@ const PUBLIC_FILES = [
 ];
 ```
 
+### Render.yaml Routes Warning
+
+**DO NOT** add catch-all rewrite rules to `render.yaml`. This will break static file serving:
+
+```yaml
+# ❌ WRONG - This breaks everything
+routes:
+  - type: rewrite
+    source: /*
+    destination: /404.html
+```
+
+Render automatically serves `404.html` for missing files on static sites. No custom route is needed.
+
 ### Pre-deployment Checklist
 - [ ] Verify all images load (webp format)
 - [ ] Test newsletter form submission

--- a/SETUP_REQUIREMENTS.md
+++ b/SETUP_REQUIREMENTS.md
@@ -157,9 +157,18 @@ index.html
 contact.html
 privacy.html
 terms.html
+voucher-terms.html
 404.html
 coming-soon.html
+welcome.html
+robots.txt
+sitemap.xml
+llms.txt
 favicon.ico
+favicon.png
+favicon-192.png
+apple-touch-icon.png
+svg_favicon.svg
 ```
 
 **Folders Included:**
@@ -217,8 +226,10 @@ lumicello_website/
 ├── contact.html            # Contact page with Formspree form
 ├── privacy.html            # Privacy Policy
 ├── terms.html              # Terms of Service
+├── voucher-terms.html      # Voucher T&C (unlisted)
 ├── 404.html                # Custom 404 page
 ├── coming-soon.html        # Coming Soon page (For Educators)
+├── welcome.html            # Newsletter confirmation page
 ├── favicon.ico             # Site favicon
 ├── css/
 │   ├── variables.css       # Design tokens

--- a/build.js
+++ b/build.js
@@ -19,6 +19,7 @@ const PUBLIC_FILES = [
     'contact.html',
     'privacy.html',
     'terms.html',
+    'voucher-terms.html',
     '404.html',
     'coming-soon.html',
     'welcome.html',

--- a/render.yaml
+++ b/render.yaml
@@ -56,7 +56,3 @@ projects:
             frame-ancestors 'none';
             base-uri 'self';
             object-src 'none';
-      routes:
-        - type: rewrite
-          source: /*
-          destination: /404.html


### PR DESCRIPTION
The new page was returning 404 because it wasn't included in the
PUBLIC_FILES whitelist in build.js, so it never got copied to dist/.