### PR TITLE
Fix voucher terms page routing issue

### DIFF
--- a/build.js
+++ b/build.js
@@ -19,7 +19,6 @@ const PUBLIC_FILES = [
     'contact.html',
     'privacy.html',
     'terms.html',
-    'voucher-terms.html',
     '404.html',
     'coming-soon.html',
     'welcome.html',
@@ -36,8 +35,7 @@ const PUBLIC_FILES = [
 const PUBLIC_FOLDERS = [
     'css',
     'js',
-    'assets',
-    'voucher-terms'
+    'assets'
 ];
 
 /**
@@ -99,6 +97,16 @@ function build() {
         } else {
             console.log(`   ⚠ ${folder}/ (not found, skipping)`);
         }
+    }
+
+    // Create extensionless voucher-terms file for clean URL support
+    // This allows /voucher-terms to work (with Content-Type header in render.yaml)
+    console.log('\n📝 Creating clean URL files...');
+    const voucherTermsSource = 'voucher-terms/index.html';
+    const voucherTermsDest = path.join(DIST_DIR, 'voucher-terms');
+    if (fs.existsSync(voucherTermsSource)) {
+        fs.copyFileSync(voucherTermsSource, voucherTermsDest);
+        console.log('   ✓ voucher-terms (extensionless file for clean URL)');
     }
 
     // Summary

--- a/js/components.js
+++ b/js/components.js
@@ -10,7 +10,8 @@ const isHomepage =
     window.location.pathname === '';
 
 // Helper to get correct href based on current page
-const getHref = anchor => (isHomepage ? anchor : `index.html${anchor}`);
+// Use absolute paths to work from any subdirectory (e.g., /voucher-terms/)
+const getHref = anchor => (isHomepage ? anchor : `/${anchor}`);
 
 // Configuration for navigation links
 const NAV_LINKS = [
@@ -64,8 +65,8 @@ function generateNavigation() {
     return `
     <nav class="nav-wrapper">
         <div class="nav-container">
-            <a href="index.html" class="logo">
-                <img src="assets/images/lumicello_logo.webp" alt="Lumicello" class="logo-image">
+            <a href="/" class="logo">
+                <img src="/assets/images/lumicello_logo.webp" alt="Lumicello" class="logo-image">
             </a>
 
             <ul class="nav-links">
@@ -108,8 +109,8 @@ function generateFooter() {
         <div class="footer-container">
             <div class="footer-grid">
                 <div class="footer-brand">
-                    <a href="index.html" class="logo">
-                        <img src="assets/images/lumicello_logo.webp" alt="Lumicello" class="logo-image">
+                    <a href="/" class="logo">
+                        <img src="/assets/images/lumicello_logo.webp" alt="Lumicello" class="logo-image">
                     </a>
                     <p class="footer-tagline">Every child has a light inside. We help it shine.</p>
                 </div>

--- a/render.yaml
+++ b/render.yaml
@@ -23,9 +23,13 @@ projects:
       renderSubdomainPolicy: disabled
       routes:
         - type: redirect
-          source: /voucher-terms
-          destination: /voucher-terms/
+          source: /voucher-terms/
+          destination: /voucher-terms
       headers:
+        # Content-Type for extensionless voucher-terms file
+        - path: /voucher-terms
+          name: Content-Type
+          value: text/html; charset=utf-8
         # Security Headers - See SECURITY_DECISIONS.md for details
         - path: /*
           name: X-Frame-Options


### PR DESCRIPTION
- Use absolute paths in components.js for logo/nav (fixes broken images on subpaths)
- Build extensionless voucher-terms file instead of folder for clean URL
- Add Content-Type header in render.yaml for proper MIME type
- Reverse redirect direction: /voucher-terms/ → /voucher-terms